### PR TITLE
fix(admin): use the correct `register` method

### DIFF
--- a/djangotest/kore/admin.py
+++ b/djangotest/kore/admin.py
@@ -2,4 +2,4 @@ from django.contrib import admin
 from djangotest.kore.models import Post
 
 # Register your models here.
-admin.register(Post, admin.ModelAdmin)
+admin.site.register(Post, admin.ModelAdmin)


### PR DESCRIPTION
we were supposed to call `admin.site.register()` instead of `admin.register()`
